### PR TITLE
Revert "Bump nokogiri from 1.13.8 to 1.13.9"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.9-x86_64-linux)
+    nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.2.1)


### PR DESCRIPTION
Reverts github/codespaces-rails#3

Causing prebuild failures.