### PR TITLE
Ruby on rails template: Remove ruby Feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,5 @@
 {
   "image": "mcr.microsoft.com/devcontainers/universal:2",
-  "features": {
-    "ghcr.io/devcontainers/features/ruby:1": {}
-  },
   "hostRequirements": {
     "cpus": 4
   },


### PR DESCRIPTION
Ref: https://github.com/devcontainers/features/issues/601 & https://github.com/devcontainers/images/pull/623

The `universal` image has ruby version `3.2.2` installed, the dev container is trying to install the same version (`3.2.2`) with the `ruby Feature` . This is currently failing due to https://github.com/devcontainers/features/issues/601

Hence, until https://github.com/devcontainers/features/issues/601 is fixed, we should remove the ruby Feature from the dev container.

More details - 

```
Two weeks ago, I merged in https://github.com/devcontainers/images/pull/623 which updates ruby versions to `3.2` & `3.1` for the `universal` image (See [here](https://github.com/devcontainers/images/pull/623/files#diff-0a764bd0944b79c46597d08357a72f308324874b8e25e7d46f302ecc0bc47bafL41-L42))

The Ruby on Rails template is again trying to again install ruby `3.2.2` (via Ruby Feature) on top of the universal image (which already has `3.2.2`)

I believe things were working fine before, because universal image had `3.1` pinned, and Ruby Feature was installing `3.2`

```