### PR TITLE
Use `ruby-lsp` ruby extension instead of a deprecated one

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
     },
     "vscode": {
       "extensions": [
-        "rebornix.Ruby"
+        "Shopify.ruby-lsp"
       ]
     }
   },


### PR DESCRIPTION
`rebornix.Ruby` is deprecated and VSCode itself recommends installing `ruby-lsp` as a substitution - https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp

<img width="742" alt="image" src="https://github.com/github/codespaces-rails/assets/5512772/f03e3ffe-8bf0-4891-b714-8d4ca654fd34">

<img width="826" alt="image" src="https://github.com/github/codespaces-rails/assets/5512772/fe184841-e603-4c46-a222-0960722935b5">

`ruby-lsp` is the officially recommended extension for Ruby - https://code.visualstudio.com/docs/languages/ruby

So let's use it by default and help developers to avoid manually uninstalling the deprecated extension 