### PR TITLE
Bump ruby to 3.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "~> 3.3"
+ruby "~> 3.3.0"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,7 +352,7 @@ DEPENDENCIES
   webdrivers
 
 RUBY VERSION
-   ruby 3.3.0p0
+   ruby 3.3.1p55
 
 BUNDLED WITH
    2.5.3


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-3-1-released/