### PR TITLE
Remove extra 'the' from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 Welcome to your shiny new Codespace running Rails! We've got everything fired up and running for you to explore Rails.
 
-You've got a blank canvas to work on from a git perspective as well. There's a single initial commit with the what you're seeing right now - where you go from here is up to you!
+You've got a blank canvas to work on from a git perspective as well. There's a single initial commit with what you're seeing right now - where you go from here is up to you!
 
 Everything you do here is contained within this one codespace. There is no repository on GitHub yet. If and when you’re ready you can click "Publish Branch" and we’ll create your repository and push up your project. If you were just exploring then and have no further need for this code then you can simply delete your codespace and it's gone forever.


### PR DESCRIPTION
Minor grammar fix - removed the word "the" from the sentence, "There's a single initial commit with the what you're seeing right now - where you go from here is up to you!"