### PR TITLE
Update erb to 6.0.4 to fix deserialization guard bypass

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
     drb (2.2.3)
-    erb (6.0.2)
+    erb (6.0.4)
     erb_lint (0.9.0)
       activesupport
       better_html (>= 2.0.1)


### PR DESCRIPTION
## Summary

Updates the `erb` gem from 6.0.2 to 6.0.4 to fix the `@_init` deserialization guard bypass via `def_module` / `def_method` / `def_class`.

Fixes https://github.com/github/codespaces-rails/security/dependabot/112